### PR TITLE
Keep sugar lumps above 100

### DIFF
--- a/cookieAutoPlayBeta.js
+++ b/cookieAutoPlayBeta.js
@@ -393,10 +393,9 @@ AutoPlay.useLump = function() { // recursive call to handle many sugar lumps
 	  return; 
 	} 
   }
-  if (Game.lumps<99) return; // collect lumps for  better cps
   for (var i = Game.ObjectsById.length-1; i>=0; i--) {
     var me = Game.ObjectsById[i]; 
-	if (me.level<10 && me.level<Game.lumps) { 
+	if (me.level<10 && me.level+99<Game.lumps) { 
 	  me.levelUp(); AutoPlay.useLump(); return;
 	} 
   }

--- a/cookieAutoPlayBeta.js
+++ b/cookieAutoPlayBeta.js
@@ -11,6 +11,7 @@ AutoPlay.delay = 0;
 AutoPlay.night = false;
 AutoPlay.finished = false;
 AutoPlay.deadline = 0;
+AutoPlay.useLumps = false;
 
 AutoPlay.run = function() {
   if (Game.AscendTimer>0 || Game.ReincarnateTimer>0) return;
@@ -381,6 +382,7 @@ AutoPlay.harvestLump = function() {
 }
 
 AutoPlay.useLump = function() { // recursive call to handle many sugar lumps
+  AutoPlay.useLumps = false;
   if (!Game.lumps) return;
   for (var i in AutoPlay.level1Order) { 
     var me = Game.ObjectsById[AutoPlay.level1Order[i]]; 
@@ -393,11 +395,16 @@ AutoPlay.useLump = function() { // recursive call to handle many sugar lumps
 	  return; 
 	} 
   }
+  AutoPlay.useLumps = true;
   for (var i = Game.ObjectsById.length-1; i>=0; i--) {
     var me = Game.ObjectsById[i]; 
-	if (me.level<10 && me.level+99<Game.lumps) { 
-	  me.levelUp(); AutoPlay.useLump(); return;
-	} 
+    if (me.level<10) {
+      if (me.level+100<Game.lumps) {
+        me.levelUp(); AutoPlay.useLump(); return;
+      } else {
+        AutoPlay.useLumps = false;
+      }
+    } 
   }
 }
 
@@ -467,7 +474,7 @@ AutoPlay.handleMinigames = function() {
     sp = g.spells["conjure baked goods"];
 	if (AutoPlay.cpsMult>100) {
 	  if (g.magic>=g.getSpellCost(sp)) { g.castSpell(sp); return; }
-	  if (Game.lumps>100) { g.lumpRefill.click(); }
+	  if (AutoPlay.useLumps && Game.lumps>100) { g.lumpRefill.click(); }
 	}
   }
   // temples: pantheon =============================


### PR DESCRIPTION
I haven't run the numbers or anything (or tested this change!), but I noticed that when it hits 99 sugar lumps the bot seems to immediately consume 10-20 of them, and I think this is why.

Since there's a CPS bonus for up to 100 lumps, this change makes it pick a slightly different strategy; it will wait until it has 105 lumps before buying something that requires 5 lumps, leaving the total always at 100 or higher.

The first purchases (to unlock minigames and level them to 10) are exempt from this, as before; it will buy those as soon as it can.