### PR TITLE
Increase wrinkler spawn rate when trying to pop them

### DIFF
--- a/cookieAutoPlayBeta.js
+++ b/cookieAutoPlayBeta.js
@@ -787,6 +787,7 @@ AutoPlay.seedCalendar = function(game,sector) {
   }
   AutoPlay.plantCookies = false;
   AutoPlay.switchSoil(game,sector,(AutoPlay.plantPending)?'fertilizer':'clay');
+  if (AutoPlay.poppingWrinklers && game.plants['wrinklegill'].unlocked) return 'wrinklegill'; // faster wrinklers
   //use garden to get cps and sugarlumps
   if (game.plants['bakeberry'].unlocked && 
       AutoPlay.lumpRelatedAchievements.every(function(a) { 
@@ -912,8 +913,10 @@ AutoPlay.removeSpirit = function(slot, god) {
 //===================== Handle Wrinklers ==========================
 AutoPlay.nextWrinkler = 0;
 AutoPlay.wrinklerTime = 0;
+AutoPlay.poppingWrinklers = false;
 
 AutoPlay.handleWrinklers = function() {
+  AutoPlay.poppingWrinklers = false;
   if (!Game.Upgrades["One mind"].bought) return;
   var doPop = (Game.season=="easter" || Game.season=="halloween");
   doPop = doPop && !AutoPlay.seasonFinished(Game.season);
@@ -923,6 +926,7 @@ AutoPlay.handleWrinklers = function() {
     (AutoPlay.endPhase() && !Game.Achievements["Last Chance to See"].won);
   if (doPop) {
 	AutoPlay.setDeadline(AutoPlay.now+20000);
+    AutoPlay.poppingWrinklers = true;
     AutoPlay.addActivity("Popping wrinklers for droppings and/or achievements.");
     Game.wrinklers.forEach(function(w) { if (w.close==1) w.hp = 0; } );
   } else if ((((AutoPlay.now-Game.startDate) > 10*24*60*60*1000) || AutoPlay.grinding()) && 

--- a/cookieAutoPlayBeta.js
+++ b/cookieAutoPlayBeta.js
@@ -479,7 +479,9 @@ AutoPlay.handleMinigames = function() {
   // temples: pantheon =============================
   if (Game.isMinigameReady(Game.Objects["Temple"])) {
 	var age = AutoPlay.now-Game.lumpT;
-    if (Game.lumpRipeAge-age < 61*60*1000 && !AutoPlay.cheatLumps) 
+    if (AutoPlay.poppingWrinklers)
+        AutoPlay.assignSpirit(0,"scorn",0);
+    else if (Game.lumpRipeAge-age < 61*60*1000 && !AutoPlay.cheatLumps) 
 	  AutoPlay.assignSpirit(0,"order",0); 
 	else if (AutoPlay.preNightMode() && Game.lumpOverripeAge-age < 9*60*60000 && 
 	    (new Date).getMinutes()==59 && !AutoPlay.cheatLumps) 


### PR DESCRIPTION
Again I'm not sure if the maths checks out, but this seems like a useful idea at first glance.

When the game hits a point where it wants to pop wrinklers as fast as possible (in my case, it's when trying to get the shiny wrinkler achievement), this makes it plant out the garden with wrinklegill (if it can, and it has nothing better to do) in order to increase the wrinkler spawn rate.

It also assigns Skruuia to the first slot in the temple to further increase the spawn rate.  (I wasn't sure if it was a good idea to bump Mokalsium/Rigidel into the second slot, due to the limited swap mechanic, so for now it just doesn't.)