### PR TITLE
Cookie Monster strategy

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -52,6 +52,8 @@ modifications:
 second and CPS.
 - The estimated bonus for golden cookie upgrades are estimated as 50% of the 
 current CPS.
+- Upgrades that affect costs of upgrades or other aspects of the game are
+given reasonable estimates as bonuses (but mostly guesses).
 Other upgrades (season switcher, etc) are handled separately from this
 calculation.
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -21,7 +21,41 @@ Relax. The bot will still work, it only does not handle all of the new features.
 ### How can I contribute?
 The bot needs regular maintenance, in particular when there is a new version of cookie clicker. If you are interested in contributing, please contact theprinzstani@gmail.com.
 
+## Saving Strategy
+The bot will maintain a bank of cookies to try and maximize profits from
+Lucky golden cookies without delaying purchasing too much.  Within the options,
+the strategy can be set to no savings, luck, or lucky-frenzy.  These manual
+settings will just wait until the amount of cookies are saved before purchasing
+buildings, upgrades, or plants.
+
+### Auto
+The automatic saving strategy dynamically adjusts the amount saved based on the
+current bank and upgrades purchased.  No cookies will be saved for the first
+30 minutes of any run.  Once lucky day and serendipity are purchase, the bot 
+will start to save to the max for lucky cookies.  When get lucky is purchased,
+it then starts to save to the max lucky during frenzy.
+
+Any time the bank is less than 80% of the current target, the bot will rescale
+the target.  This occurs if something is bought manually to decrease the bank
+or if a large income multiplier is purchased.  After rescaling, the bot will
+slowly increase the savings.  The current saving target and percentage towards
+goal are displayed when hovering over the version in the lower left.
+
 ## Buying Algorithm
+
+### Cookie Monster Integration
+If the [Cookie Monster](https://github.com/Aktanusa/CookieMonster/)
+plugin is active, the bot will use the payback
+period calculated by CM to determine which item to purchase next, with a few
+modifications:
+- The estimated bonus for mouse upgrades are based on the current clicks per
+second and CPS.
+- The estimated bonus for golden cookie upgrades are estimated as 50% of the 
+current CPS.
+Other upgrades (season switcher, etc) are handled separately from this
+calculation.
+
+If CM isn't running, the bot will fall back on the algorithm described below.
 
 ### What is the next building to be bought?
 The next building is the cheapest building that gives at least 50% of the max possible gain in cpc per cookie invested.

--- a/README.md
+++ b/README.md
@@ -107,5 +107,6 @@ Before submitting a bug report, please reload the bot, as it is continuously imp
 * **[SearchAndDestroy](https://github.com/SearchAndDestroy)**: Tampermonkey script
 * **[AlexFolland](https://github.com/AlexFolland)**: Options and small fixes
 * **[corvidian](https://github.com/corvidian)**: Elder handling and optimization
+* **[troycomi](https://github.com/troycomi)**: Savings, cookie monster integration
 
 We need more contributors. Please contact theprinzstani@gmail.com if you are interested.

--- a/cookieAutoPlayBeta.js
+++ b/cookieAutoPlayBeta.js
@@ -1575,10 +1575,15 @@ AutoPlay.handleDragon = function() {
       Game.ToggleSpecialMenu(0);
       if (obj == null)
         return;
-      if (obj == 'buy150')  // after sacrificing 50 or 200 of all
+      if (obj == 'buy150'){  // after sacrificing 50 or 200 of all
+        // handle garden before buying (low cps)
+        if (Game.Objects['Farm'].amount == 0)
+          Game.Objects['Farm'].buy(1);
+        AutoPlay.handleMinigames()
         for (var o of Game.ObjectsById)
           o.buy(150 - o.amount);
-      else  // after sacrificing 100
+      }
+      else  // after sacrificing 100, get 50 back immediately
         obj.buy(50 - obj.amount);
     } 
   }

--- a/cookieAutoPlayBeta.js
+++ b/cookieAutoPlayBeta.js
@@ -314,12 +314,12 @@ AutoPlay.bestBuy = function() {
          'Nevercrack mouse', 'Armythril mouse',
          'Technobsidian mouse', 'Plasmarble mouse'].includes(u)){
       // bonus is 1% of cps * AvgClicks
-      CM.Cache.Upgrades[u].bonus = CM.Cache.AvgClicks * Game.cookiesPS * 0.01;
+      CM.Cache.Upgrades[u].bonus = CM.Cache.AvgClicks * Game.cookiesPs * 0.01;
       CM.Cache.Upgrades[u].pp = (Math.max(Game.Upgrades[u].getPrice() - (Game.cookies + CM.Disp.GetWrinkConfigBank()), 0) / Game.cookiesPs) + (Game.Upgrades[u].getPrice() / CM.Cache.Upgrades[u].bonus);
     }
     if( ['Lucky day', 'Serendipity', 'Get lucky'].includes(u)){
       // bonus is 50% of cps (just guessing!)
-      CM.Cache.Upgrades[u].bonus = Game.cookiesPS * 0.5;
+      CM.Cache.Upgrades[u].bonus = Game.cookiesPs * 0.5;
       CM.Cache.Upgrades[u].pp = (Math.max(Game.Upgrades[u].getPrice() - (Game.cookies + CM.Disp.GetWrinkConfigBank()), 0) / Game.cookiesPs) + (Game.Upgrades[u].getPrice() / CM.Cache.Upgrades[u].bonus);
 
     }

--- a/cookieAutoPlayBeta.js
+++ b/cookieAutoPlayBeta.js
@@ -279,7 +279,6 @@ AutoPlay.handleSavings = function() {
 
 AutoPlay.buyBuilding = function(building, checkAmount=1, buyAmount=1) {
   if (building.getSumPrice(checkAmount) < Game.cookies - AutoPlay.savingsGoal) {
-    console.log('Buying ' + building.name);
     building.buy(buyAmount);
     AutoPlay.setDeadline(0); 
   }
@@ -287,7 +286,6 @@ AutoPlay.buyBuilding = function(building, checkAmount=1, buyAmount=1) {
 
 AutoPlay.buyUpgrade = function(upgrade, bypass=true) {
   if (upgrade.getPrice() < Game.cookies - AutoPlay.savingsGoal) {
-    console.log('Buying ' + upgrade.name);
     upgrade.buy(bypass);
     AutoPlay.setDeadline(0); 
   }
@@ -368,15 +366,14 @@ AutoPlay.bestBuy = function() {
 
   // for the following, pp < 1 indicates we can pay off the cost in less
   // than a second.  It's better to just buy it instead of checking it repeatedly
+  // CheckDragon twice in case the pp < 1 case set us over the limit
   for(var b in check_obj){
-    if(AutoPlay.checkDragon(b)){
-      if(check_obj[b].pp < 1)
-        AutoPlay.buyBuilding(Game.Objects[b], buy_amt, buy_amt);
-      if(check_obj[b].pp < minpp){
-        minpp = check_obj[b].pp;
-        best = b;
-        type = 'building';
-      }
+    if(AutoPlay.checkDragon(b) && check_obj[b].pp < 1)
+      AutoPlay.buyBuilding(Game.Objects[b], buy_amt, buy_amt);
+    if(check_obj[b].pp < minpp && AutoPlay.checkDragon(b)){
+      minpp = check_obj[b].pp;
+      best = b;
+      type = 'building';
     }
   }
 
@@ -414,7 +411,7 @@ AutoPlay.bestBuy = function() {
   if (AutoPlay.deadline != 0) {
     if ((AutoPlay.now-Game.startDate) < 10*60*1000 &&
         Game.cookiesPs != 0)
-      AutoPlay.deadline = AutoPlay.now+1000; // wait one second before next step
+      AutoPlay.deadline = AutoPlay.now+5000; // wait five seconds before next step
     else
       AutoPlay.addActivity('Waiting to buy ' + best);
   }
@@ -510,7 +507,6 @@ AutoPlay.handleSeasons = function() {
 }
 
 AutoPlay.valentineUpgrades = range(169,174);
-// AutoPlay.christmasUpgrades = [168].concat(range(152,166)).concat(range(143,149));
 AutoPlay.christmasUpgrades = [168];  // just wait for dominion
 AutoPlay.easterUpgrades = range(210,229);
 AutoPlay.halloweenUpgrades = range(134,140);
@@ -955,7 +951,6 @@ AutoPlay.plantSeed = function(game,seed,whereX,whereY) {
   if (!game.canPlant(game.plants[seed])) return;
   if (game.plants[seed].cost * 60 * Game.cookiesPs > Game.cookies - AutoPlay.savingsGoal)
     return;
-  console.log("Planting " + seed + " at (" + whereX + ", " + whereY + ")");
   game.useTool(game.plants[seed].id,whereX,whereY);
 }
 
@@ -1003,7 +998,6 @@ AutoPlay.plantSeeds = function(game, targets) {
       whereX = target[1],
       whereY = target[2];
     game.useTool(game.plants[seed].id, whereX, whereY);
-    console.log("Planting " + seed + " at (" + whereX + ", " + whereY + ")");
   }
 }
 

--- a/cookieAutoPlayBeta.js
+++ b/cookieAutoPlayBeta.js
@@ -366,11 +366,17 @@ AutoPlay.bestBuy = function() {
     check_obj = CM.Cache.Objects10;
   }
 
+  // for the following, pp < 1 indicates we can pay off the cost in less
+  // than a second.  It's better to just buy it instead of checking it repeatedly
   for(var b in check_obj){
-    if(AutoPlay.checkDragon(b) && check_obj[b].pp < minpp){
-      minpp = check_obj[b].pp;
-      best = b;
-      type = 'building';
+    if(AutoPlay.checkDragon(b)){
+      if(check_obj[b].pp < 1)
+        AutoPlay.buyBuilding(Game.Objects[b], buy_amt, buy_amt);
+      if(check_obj[b].pp < minpp){
+        minpp = check_obj[b].pp;
+        best = b;
+        type = 'building';
+      }
     }
   }
 
@@ -1268,6 +1274,7 @@ AutoPlay.handleAscend = function() {
     AutoPlay.doReincarnate(); 
     AutoPlay.findNextAchievement(); 
     AutoPlay.setDeadline(0); 
+    AutoPlay.savingsStart = AutoPlay.now;
     return; 
   }
   if (Game.ascensionMode==1 && !AutoPlay.canContinue()) 
@@ -1564,9 +1571,21 @@ AutoPlay.handleDragon = function() {
   if (Game.Upgrades["A crumbly egg"].unlocked) {
     if (Game.dragonLevel<Game.dragonLevels.length-1 && 
 	    Game.dragonLevels[Game.dragonLevel].cost()) {
+      let obj = null;
+      if (Game.dragonLevel >=5 && Game.dragonLevel < 21)
+        obj = Game.ObjectsById[Game.dragonLevel - 5];
+      else if (Game.dragonLevel == 21 || Game.dragonLevel == 22)
+        obj = 'buy150';
       Game.specialTab = "dragon"; 
       Game.UpgradeDragon();
       Game.ToggleSpecialMenu(0);
+      if (obj == null)
+        return;
+      if (obj == 'buy150')  // after sacrificing 50 or 200 of all
+        for (var o of Game.ObjectsById)
+          o.buy(150 - o.amount);
+      else  // after sacrificing 100
+        obj.buy(50 - obj.amount);
     } 
   }
   if (Game.dragonLevel>=5) wantedAura=1; // kitten (breath of milk)

--- a/cookieAutoPlayBeta.js
+++ b/cookieAutoPlayBeta.js
@@ -246,7 +246,14 @@ AutoPlay.handleSavings = function() {
           ' minutes!');
     return;
   }
-  AutoPlay.savingsGoal = Game.unbuffedCps * 60 * 100;
+  if (Game.UpgradesById[52].bought && Game.UpgradesById[53].bought) {
+    AutoPlay.savingsGoal = Game.unbuffedCps * 60 * 100;
+  }
+  else {
+    AutoPlay.savingsGoal = 0;
+    AutoPlay.addActivity('Not saving until GC upgrades purchased');
+    return;
+  }
   if (Game.UpgradesById[86].bought)  // get lucky
     AutoPlay.savingsGoal *= 7;
   // scale goal between 0 and 1 based on elapsed time
@@ -295,9 +302,9 @@ AutoPlay.bestBuy = function() {
     return;
   }
 
-  let best = null;
+  let best = Game.ObjectsById[0].name;
   let minpp = Infinity;
-  let type = null;
+  let type = 'building';
 
   // change cookie monster values for some 'infinite' pp upgrades
   for(var u in CM.Cache.Upgrades) {
@@ -319,7 +326,7 @@ AutoPlay.bestBuy = function() {
   }
 
   // upgrades
-  if (Game.Achievements["Hardcore"].won || Game.UpgradesOwned==0){
+  if (Game.Achievements["Hardcore"].won || Game.UpgradesOwned!=0){
     for(var u of Game.UpgradesInStore){
       if(!AutoPlay.avoidbuy(u) && CM.Cache.Upgrades[u.name].pp < minpp){
         minpp = CM.Cache.Upgrades[u.name].pp;
@@ -362,9 +369,10 @@ AutoPlay.bestBuy = function() {
       (AutoPlay.now-Game.startDate) > 3*24*60*60*1000) 
       Game.Upgrades["Sugar frenzy"].buy();
 
-  // nothing bought, within first 10 minutes
+  // nothing bought, within first 10 minutes, have income
   if (AutoPlay.deadline != 0 &&
-      (AutoPlay.now-Game.startDate) < 10*60*1000) {
+      (AutoPlay.now-Game.startDate) < 10*60*1000 &&
+      Game.cookiesPs != 0) {
     AutoPlay.deadline = AutoPlay.now+1000; // wait one second before next step
   }
 

--- a/cookieAutoPlayBeta.js
+++ b/cookieAutoPlayBeta.js
@@ -374,7 +374,7 @@ AutoPlay.bestBuy = function() {
         Game.cookiesPs != 0)
       AutoPlay.deadline = AutoPlay.now+1000; // wait one second before next step
     else
-      AutoPlay.addActivity('Next buy is ' + best);
+      AutoPlay.addActivity('Waiting to buy ' + best);
   }
 
   return;

--- a/cookieAutoPlayBeta.js
+++ b/cookieAutoPlayBeta.js
@@ -271,7 +271,6 @@ AutoPlay.handleSavings = function() {
   // this happens if you stop the bot for a while or buy something with
   // a big payback
   if (fractionSaved < 0.8) {
-    console.log('Rescaling');
     AutoPlay.savingsStart = AutoPlay.now - startTime -
       targetTime * fractionSaved / scaling;  // fraction towards goal
   }
@@ -295,13 +294,14 @@ AutoPlay.buyUpgrade = function(upgrade, bypass=true) {
 
 //======================= CM Strategy ============================
 AutoPlay.bestBuy = function() {
-  // if cookie monster isn't installed or within first 10 minutes
+  // if cookie monster isn't installed
   if (typeof CM == 'undefined') {
     AutoPlay.handleBuildings();
     AutoPlay.handleUpgrades();
     return;
   }
 
+  // initialize with cursor, when cps = 0 all pp = inf
   let best = Game.ObjectsById[0].name;
   let minpp = Infinity;
   let type = 'building';
@@ -356,7 +356,6 @@ AutoPlay.bestBuy = function() {
     }
   }
 
-  console.log('Next buy is ' + best);
   if (type == 'building')
     AutoPlay.buyBuilding(Game.Objects[best], buy_amt, buy_amt);
 
@@ -370,10 +369,12 @@ AutoPlay.bestBuy = function() {
       Game.Upgrades["Sugar frenzy"].buy();
 
   // nothing bought, within first 10 minutes, have income
-  if (AutoPlay.deadline != 0 &&
-      (AutoPlay.now-Game.startDate) < 10*60*1000 &&
-      Game.cookiesPs != 0) {
-    AutoPlay.deadline = AutoPlay.now+1000; // wait one second before next step
+  if (AutoPlay.deadline != 0) {
+    if ((AutoPlay.now-Game.startDate) < 10*60*1000 &&
+        Game.cookiesPs != 0)
+      AutoPlay.deadline = AutoPlay.now+1000; // wait one second before next step
+    else
+      AutoPlay.addActivity('Next buy is ' + best);
   }
 
   return;


### PR DESCRIPTION
This is a monolithic PR, so let me know if some things should be separated or if you disagree with some of the changes.

The main change is that when cookie monster (CM) is loaded in addition to cookie bot, the bot will read the payback period to decide what to buy.  This may help with #34.  From what I can tell, the difference between the bot and CM is that CM accounts for all sources of income, instead of just the building base CPS when deciding most efficient buy.  So the bot looks at the CPS of a farm alone, without accounting for the increase due to cursors, synergies etc.  The cookie clicker code for upgrades is a mess, so handling those looks like a headache!  Instead of reimplementing CM, I chose to use it directly, adding in PP for upgrades that didn't have a direct bonus to CPS (clicking, GC upgrades, season specials, etc).  The only part I'm not sure is working is the 5 elder pledges; if someone has a save file they can quickly test on that'd be great.

Other changes, in order of diff appearance:
1. Added information on saving strategy and buying algorithm to FAQ
2. Added me to the contributors
3. Changed saving strategy to not start until first two GC upgrades are purchased.  Fixed not saving for first 30 minutes to work between ascends
4. Removed logging calls
5. For CM purchasing, I added a check to the payback period to immediately purchase 10 buildings or an upgrade if the PP < 1.  This ends up accelerating the beginning quite a bit, possibly keeping up with just purchasing 100 buildings in the beginning.
6. Another cause of slowdown following ascend is that once a building can't be purchased, the bot waits for 1 minute before handling purchases.  I modified this to be 5 seconds for the first 10 minutes which keeps things moving quickly.
7. Changed season handling.  It made more sense to me to go to valentines early as it's a quick source of CPS.  As such, I have the bot start on Christmas until dominion is unlocked, then go Valentines -> Easter -> Halloween -> Christmas.  The only downside I see is not having reindeer for the first part of the game and not having wrinklers immediately for easter, so maybe finishing Christmas or waiting for one mind would be better?
8. Changed wrinkler handling.  Waiting 10 days to start popping wrinklers seemed too long to wait.  Cookies in the bank are worth less than buying a building, so keeping the wrinkler bank low seems like a better strategy.  I have it pop the oldest wrinkler when all spots are full.  I realize this drops effective CPS but I like the extra influx of income in a more timely fashion.  Maybe a compromise would be to pop once an hour, removing checks for playing longer than 10 days?
9. Indentation in handleAscend.  I was looking at the lucky digit code and was having trouble reading it with the previous indentation.  Didn't modify code.
10. Dragon handling.  First, after sacrificing 100 of a building, 50 of that building is purchased immediately.  When sacrificing 50 or 200 of everything, handle the garden (as cps is low) and then buy 150 of everything.  This helps speed up the early game to recover from sacrifices quickly.  Next, while the dragon is still in training, limit the number of buildings purchased to just cover what's needed to sacrifice.  Before the initial sacrifice of 100, buy up to 100, then up to 50, then up to 200, then no limit.  This may cost cookies from inefficient purchases, but sacrificing the first X buildings is cheaper (and it's fun to watch!)