### PR TITLE
Click more during click frenzy/dragonflight

### DIFF
--- a/cookieAutoPlayBeta.js
+++ b/cookieAutoPlayBeta.js
@@ -206,8 +206,8 @@ AutoPlay.handleClicking = function() {
   else{  // ClickMode == 1
     Game.ClickCookie();
     if ('Click frenzy' in Game.buffs || 'Dragonflight' in Game.buffs){
-      for (var i = 1; i<10; i++)
-        setTimeout(function(){Game.ClickCookie(0, 10*Game.computedMouseCps);}, 30*i);
+      for (var i = 1; i<5; i++)
+        setTimeout(function(){Game.ClickCookie(0, Game.computedMouseCps);}, 30*i);
     }
   }
 }
@@ -1362,8 +1362,8 @@ AutoPlay.canContinue = function() {
   if (!Game.Achievements["Speed baking III"].won &&
             (AutoPlay.now-Game.startDate <= 1000*60*15)) {
     AutoPlay.addActivity("Trying to get achievement: Speed baking III.");
-    for (var i = 1; i<10; i++)
-      setTimeout(function(){Game.ClickCookie(0, 10*Game.computedMouseCps);}, 30*i);
+    for (var i = 1; i<5; i++)
+      setTimeout(function(){Game.ClickCookie(0, Game.computedMouseCps);}, 30*i);
   } else if (!Game.Achievements["Speed baking II"].won &&
             (AutoPlay.now-Game.startDate <= 1000*60*25)) {
     AutoPlay.addActivity("Trying to get achievement: Speed baking II.");


### PR DESCRIPTION
- Added detection of click frenzy and dragon flight in active buffs.
When hit with click mode set to auto, will click at 10x 'light speed', which I think is around 300 per second.
If that's too fast can easily scale back.
- Modified activity reporting for neverclick, hardcore and speed baking
to show more logically (e.g. going for speed baking III before II)
- Moved activity reporting for neverclick to canContinue function
exclusively. Added check for first run to display neverclick and
hardcore targets.
- Changed setDealine during purchases to -1 to suppress display of next
purchase in best buy consistently during speed baking.
- Added extra clicking during speed baking III to get 1M in about 5
minutes.  Again, this is set to 10x light speed which may be too fast.
- Changed detection of first purchase from cps == 0 to neverclick won
- Added check that upgrade isn't bought to fix purchasing of toggles.