### PR TITLE
Quick fix for Stock Market overspending

### DIFF
--- a/cookieAutoPlayBeta.js
+++ b/cookieAutoPlayBeta.js
@@ -1292,6 +1292,7 @@ AutoPlay.switchSoil = function(game,sector,which) {
 
 // banks: stock market =============================
 AutoPlay.handleStockMarket = function() {
+  if (Date.now() < AutoPlay.resetTime + 3600000) return;
   if (Game.isMinigameReady(Game.Objects["Bank"]) && !AutoPlay.wantAscend) {
     var market = Game.Objects["Bank"].minigame;
     if (market.brokers < market.getMaxBrokers()) { // buy brokers
@@ -1651,6 +1652,7 @@ AutoPlay.doReincarnate = function() {
     Game.PickAscensionMode(); Game.nextAscensionMode=1; Game.ConfirmPrompt();
   }
   Game.Reincarnate(true);
+  AutoPlay.resetTime=Date.now(); // save the current date for things that need to be delayed after reincarnating
   AutoPlay.neverclickWarn=true;
   AutoPlay.ascendLimit = 0.9*Math.floor(2*(1-Game.ascendMeterPercent));
 }


### PR DESCRIPTION
Closes #64 (hopefully)
Disables the stock market for 1 hour to hopefully fix (or at least delay) the bot from spending all of the cookies on the stock market so other things can be done. 
Stock market still needs to have saving implemented.
Adds a variable which can be used to delay things after reincarnation.

I have tested this and it seems to work as it delayed the buying of the max-level office until the timer finished.

Stock Market still needs to be implemented into the saving system. That is above me as I do not know how it works, but after that is fixed, this code can likely be completely removed.

Can someone else please do some quick tests and then merge this PR?